### PR TITLE
feat: eoaSignAddress opt for erc1271

### DIFF
--- a/src/blockchains/ethereum.ts
+++ b/src/blockchains/ethereum.ts
@@ -86,10 +86,12 @@ async function createErc1271Link (
   provider: any,
   opts: any
 ): Promise<LinkProof> {
-  const res = await createEthLink(did, account, provider, opts)
+  const ethLinkAccount = opts?.eoaSignAccount || account
+  const res = await createEthLink(did, ethLinkAccount, provider, opts)
   await validateChainId(account, provider)
   return Object.assign(res, {
-    type: ADDRESS_TYPES.erc1271
+    type: ADDRESS_TYPES.erc1271,
+    account: account.toString()
   })
 }
 


### PR DESCRIPTION
add option to pass eoa address for signing, some providers for personal sign need an address and depending on implementation will require a eoa account rather than contract account address abstraction. ie also needed if using something like metamask with some contract account. 

For usability in future can do some detection, but this should allow all use cases now. 